### PR TITLE
BUG eslint prettier conflict

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @TDT4290-SDG-Ontology/maintainers

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Related Issue
+Closes `link to Trello issue`
+
+## Proposed changes
+- change 1
+- change 2
+
+## Additional info
+- any additional information or context 
+
+## How has this been tested?
+- [ ] Write test
+
+## Checklist
+- [ ] Tests
+- [ ] Documentation
+
+## Screenshots (if appropriate):

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -25,6 +25,8 @@ module.exports = {
     'jsx-a11y/anchor-is-valid': 'off',
     'jsx-a11y/click-events-have-key-events': 'off',
     'jsx-a11y/no-static-element-interactions': 'off',
+    // Disabled due to conflict between ESLint and Prettier
     '@typescript-eslint/lines-between-class-members': 'off',
+    '@typescript-eslint/indent': 'off',
   },
 };

--- a/frontend/src/common/d3.ts
+++ b/frontend/src/common/d3.ts
@@ -65,21 +65,21 @@ export const changeColorBasedOnType = (type: string) => {
   if (type.includes('Utviklingsområde')) nodeColor = '#FC8181';
   return nodeColor;
 };
-export const mapNodeToGraphNodeAtDefaultPosition = (x?: number, y?: number) => (
-  node: GraphNode,
-) => {
-  if (node.x) return node; // if node is already a GraphNode, just return it
-  const newNode: GraphNode = node;
-  newNode.x = x;
-  newNode.y = y;
-  newNode.vx = 0;
-  newNode.vy = 0;
-  return newNode;
-};
+export const mapNodeToGraphNodeAtDefaultPosition =
+  (x?: number, y?: number) => (node: GraphNode) => {
+    if (node.x) return node; // if node is already a GraphNode, just return it
+    const newNode: GraphNode = node;
+    newNode.x = x;
+    newNode.y = y;
+    newNode.vx = 0;
+    newNode.vy = 0;
+    return newNode;
+  };
 
-export const mapOntologyToNonClickedGraphNode = (clickedNode: GraphNode) => (
-  ontology: Ontology,
-): GraphNode => (ontology.Subject.id === clickedNode.id ? ontology.Object : ontology.Subject);
+export const mapOntologyToNonClickedGraphNode =
+  (clickedNode: GraphNode) =>
+  (ontology: Ontology): GraphNode =>
+    ontology.Subject.id === clickedNode.id ? ontology.Object : ontology.Subject;
 
 export const isD3Edge = (edge: GraphEdge | D3Edge) => typeof edge.target === 'string';
 export const isGraphEdge = (edge: GraphEdge | D3Edge) => typeof edge.target !== 'string';

--- a/frontend/src/common/regex.ts
+++ b/frontend/src/common/regex.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line import/prefer-default-export
 export const isUrl = (text: string): boolean => {
-  const regex = /[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)?/gi;
+  const regex =
+    /[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)?/gi;
   return regex.test(text);
 };

--- a/frontend/src/d3/GraphSimulation.ts
+++ b/frontend/src/d3/GraphSimulation.ts
@@ -1,3 +1,4 @@
+/*  eslint func-names: "off" */
 /*
   This file handles the entire simulation and rendering of the ontology graph.
   The entire state is managed by an ordinary JavaScript class, i.e. not a React component, as the only DOM element


### PR DESCRIPTION
## Related Issue
Closes [ESLint / Prettier bug](https://trello.com/c/qlJTmNxC/16-eslint-prettier-bug)

## Proposed changes
- Disabled conflicting rules between Prettier and ESLint
- Used `eslint --fix` to format files by new ruleset

## Additional info
- ESLint and Prettier are notorious for trying to handle the _indent_-rule in different ways. This is solved by disabling the ESLint-rule.

## How has this been tested?
- [ ] `cd backend && npm start` works

## Checklist
- [ ] Resolve error
- [ ] Check behaviour